### PR TITLE
--details option to output line, column, and html for each match

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -28,6 +28,7 @@ module.exports = function(process) {
 		.option('-j, --json', 'output each line as JSON (useful for reading the output in another app)')
 		.option('-d, --directory <string>', 'the directory to search (defaults to current working directory)', stripQuotes, process.cwd())
 		.option('-f, --files <csv list>', 'files to search through (if this is provided then extension, ignore and directory are ignored)', list)
+		.option('-D, --details', 'output line, column, and html of each match')
 		.parse(process.argv);
 
 	// Show the help if no arguments were provided
@@ -64,6 +65,7 @@ module.exports = function(process) {
 		extension: program.extension,
 		ignore: program.ignore,
 		directory: program.directory,
-		files: program.files
+		files: program.files,
+		details: program.details
 	}, output);
 };

--- a/lib/element-finder.js
+++ b/lib/element-finder.js
@@ -144,7 +144,15 @@ module.exports = function(options, progressCallback) {
 					'file': filePath,
 					'matches': matchesLen,
 					'matchesDetails': matchesDetails,
-					'message': 'Found ' + pluralise(matchesLen, 'match', 'matches') + ' in ' + filePath
+					'message': 'Found ' + pluralise(matchesLen, 'match', 'matches') + ' in ' + filePath +
+						(options.details ? (() => {
+							let output = '\n';
+							matchesDetails.forEach(detail => {
+								// Regex to remove multiple whitespaces and newlines from html
+								output += `\t[${detail.line}:${detail.column}] ${detail.html.replace(/\s{2,}/g, '')}\n`;
+							});
+							return output;
+						})(matchesDetails) : '')
 				});
 			}
 


### PR DESCRIPTION
Thank you for making this tool.  I see you've already collected line, column, and html snippet but saw no option to show that in the output.  This option `--details` or `--D` allows that.  This does not make changes to the original output, only adds to it when given the option.

Example output:
```
someone@somewhere path % elfinder -D -s "del"
Searching for "del" in 974 files in "/some/dev/path".
Found 3 matches in /some/dev/path/somewhere.html
        [58:72] <del>Bob</del>
        [60:73] <del>Jane</del>
        [62:78] <del>Jack</del>

Found 1 match in /some/dev/path/elsewhere.html
        [81:69] <del>Jill</del>


Found 4 matches in 2 files (0.015 seconds).
```